### PR TITLE
Fix SSG html contains i18n ids

### DIFF
--- a/pages/Header.js
+++ b/pages/Header.js
@@ -14,16 +14,23 @@ function Header ({lang, setLang}) {
   const [showMenu, setShowMenu] = useState(false);
   const {pathname} = useRouter();
 
+  // Get preferred language.
   useEffect(() => {
-    if (lang && i18n.languages.includes(lang)) {
-      window.localStorage.setItem('preferredLang', lang);
-      i18n.changeLanguage(lang);
+    const preferredLang = localStorage.getItem('preferredLang') ?? 'en';
+    if (preferredLang && i18n.languages.includes(preferredLang)) {
+      setLang(preferredLang);
     }
     else {
       // Set default to english.
-      window.localStorage.removeItem('preferredLang');
-      i18n.changeLanguage('en');
+      localStorage.removeItem('preferredLang');
+      setLang('en');
     }
+  }, []);
+
+  // Update language settings on select.
+  useEffect(() => {
+    i18n.changeLanguage(lang);
+    localStorage.setItem('preferredLang', lang);
   }, [lang, i18n]);
 
   function getLangs () {
@@ -47,7 +54,7 @@ function Header ({lang, setLang}) {
         </button>
       </div>
       <div className={showMenu ? classes.Links + ' ' + classes.Show : classes.Links}>
-        <select defaultValue={lang} onChange={(e) => { setLang(e.target.value); }} className={classes.SelectLang}>
+        <select value={lang} onChange={(e) => setLang(e.target.value)} className={classes.SelectLang}>
           {getLangs()}
         </select>
         <Link href='/'>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,18 +1,14 @@
 import './App.module.scss';
 import './index.css';
-import {useState, useEffect} from 'react';
+import {useState} from 'react';
 import Header from './Header';
 import i18nInit from '../src/i18nInit';
 
-if (typeof window !== 'undefined') {
-  i18nInit();
-}
+i18nInit();
 
 function App ({Component, pageProps}) {
-  const [lang, setLang] = useState(() => typeof window !== 'undefined' ? window?.localStorage?.getItem('preferredLang') : 'en');
-  useEffect(() => {
-    setLang(window.localStorage.getItem('preferredLang') ?? 'en');
-  }, []);
+  const [lang, setLang] = useState('en');
+
   return <>
     <Header lang={lang} setLang={setLang} />
     <Component {...pageProps} />

--- a/src/i18nInit.js
+++ b/src/i18nInit.js
@@ -17,8 +17,8 @@ function i18nInit () {
       'en', 'ko'
     ],
     fallbackLng: ['en', 'ko'],
-    lng: localStorage.getItem('preferredLang') || 'en',
-    debug: false
+    lng: 'en',
+    debug: false,
   }, (err) => {
     if (err)
       console.log('i18n init error', err);


### PR DESCRIPTION
Fix build output html files contain i18n IDs, showing raw IDs on initial load and flickering side effects.

Within this PR, the html files now contain English texts. Even though it still exhibits the flickering side effects when users had selected other languages, it's still better than the past.