### PR TITLE
Deploy Github Pages with GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  # This event will only trigger a workflow run if the workflow file is on the default branch.
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do not cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run export
+      - name: Create .nojekyll
+        shell: bash
+        run: touch out/.nojekyll
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload build folder
+          path: './out'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "dev": "next dev",
     "test": "next test",
     "export": "next export",
-    "predeploy": "npm run build && npm run export && touch out/.nojekyll",
-    "deploy": "git switch -c tmp && git add -f out/ && git commit -m 'Deploy to gh-pages' && git push origin `git subtree split --prefix out tmp`:gh-pages --force && git switch main && git branch -D tmp"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Previous deploy strategy was to deploy from a branch.
Switch to deploying from Github Action strategy for Continuous Deployment.