### PR TITLE
Fix infinite rerenders after setting language

### DIFF
--- a/pages/Header.jsx
+++ b/pages/Header.jsx
@@ -25,7 +25,7 @@ function Header ({lang, setLang}) {
       localStorage.removeItem('preferredLang');
       setLang('en');
     }
-  }, [i18n.languages, setLang]);
+  }, [setLang]);
 
   // Update language settings on select.
   useEffect(() => {

--- a/pages/Header.jsx
+++ b/pages/Header.jsx
@@ -25,7 +25,7 @@ function Header ({lang, setLang}) {
       localStorage.removeItem('preferredLang');
       setLang('en');
     }
-  }, [setLang]);
+  }, [i18n, setLang]);
 
   // Update language settings on select.
   useEffect(() => {


### PR DESCRIPTION
Commit 58a0cc1e1604c030b6ed5604188d7987061ab6d8 introduced a bug where the page rerenders infinitely after setting a language and refreshing the page.
It turns out `i18n.languages` array changes, and it creates infinite loops. Maybe because  it is twinned with `i18n.changeLanguage(lang)`.
https://github.com/dlguswo333/tishare-docs/blob/58a0cc1e1604c030b6ed5604188d7987061ab6d8/pages/Header.jsx#L30-L34


I don't know why the bug does not show up without a refresh.
